### PR TITLE
Fix Jenkins

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -151,7 +151,8 @@ def test_response():
     file_path = 'samples/small-dev.json'
 
     with open(file_path, 'rb') as file:
-        json_data = json.load(file)
+        file = file.read()
+        json_data = json.loads(file.decode('utf-8'))
         r = requests.post(url=model_endpoint, json=json_data)
 
     assert r.status_code == 200

--- a/tests/test.py
+++ b/tests/test.py
@@ -150,9 +150,8 @@ def test_response():
     model_endpoint = 'http://localhost:5000/model/predict'
     file_path = 'samples/small-dev.json'
 
-    with open(file_path, 'rb') as file:
-        file = file.read()
-        json_data = json.loads(file.decode('utf-8'))
+    with open(file_path, 'r') as file:
+        json_data = json.load(file)
         r = requests.post(url=model_endpoint, json=json_data)
 
     assert r.status_code == 200


### PR DESCRIPTION
Jenkins is using python 3.4 and does not automatically convert files when you try to read them with JSON resulting in this error:

```
09:54:54 =================================== FAILURES ===================================
09:54:54 ________________________________ test_response _________________________________
09:54:54 
09:54:54     def test_response():
09:54:54         model_endpoint = 'http://localhost:5000/model/predict'
09:54:54         file_path = 'samples/small-dev.json'
09:54:54     
09:54:54         with open(file_path, 'rb') as file:
09:54:54 >           json_data = json.load(file)
09:54:54 
09:54:54 tests/test.py:154: 
09:54:54 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
09:54:54 /usr/lib64/python3.4/json/__init__.py:268: in load
09:54:54     parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)
09:54:54 _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
09:54:54 
09:54:54 s = b'{"paragraphs": [{"context": "Super Bowl 50 was an American football game to determine the champion of the National F...n\t\t\t\t\t\t\t\t\t   \t  "What day was the game played on?", \n\t\t\t\t\t\t\t\t\t\t  "What is the AFC short for?"]}]}'
09:54:54 encoding = None, cls = None, object_hook = None, parse_float = None
09:54:54 parse_int = None, parse_constant = None, object_pairs_hook = None, kw = {}
09:54:54 
09:54:54     def loads(s, encoding=None, cls=None, object_hook=None, parse_float=None,
09:54:54             parse_int=None, parse_constant=None, object_pairs_hook=None, **kw):
09:54:54         """Deserialize ``s`` (a ``str`` instance containing a JSON
09:54:54         document) to a Python object.
09:54:54     
09:54:54         ``object_hook`` is an optional function that will be called with the
09:54:54         result of any object literal decode (a ``dict``). The return value of
09:54:54         ``object_hook`` will be used instead of the ``dict``. This feature
09:54:54         can be used to implement custom decoders (e.g. JSON-RPC class hinting).
09:54:54     
09:54:54         ``object_pairs_hook`` is an optional function that will be called with the
09:54:54         result of any object literal decoded with an ordered list of pairs.  The
09:54:54         return value of ``object_pairs_hook`` will be used instead of the ``dict``.
09:54:54         This feature can be used to implement custom decoders that rely on the
09:54:54         order that the key and value pairs are decoded (for example,
09:54:54         collections.OrderedDict will remember the order of insertion). If
09:54:54         ``object_hook`` is also defined, the ``object_pairs_hook`` takes priority.
09:54:54     
09:54:54         ``parse_float``, if specified, will be called with the string
09:54:54         of every JSON float to be decoded. By default this is equivalent to
09:54:54         float(num_str). This can be used to use another datatype or parser
09:54:54         for JSON floats (e.g. decimal.Decimal).
09:54:54     
09:54:54         ``parse_int``, if specified, will be called with the string
09:54:54         of every JSON int to be decoded. By default this is equivalent to
09:54:54         int(num_str). This can be used to use another datatype or parser
09:54:54         for JSON integers (e.g. float).
09:54:54     
09:54:54         ``parse_constant``, if specified, will be called with one of the
09:54:54         following strings: -Infinity, Infinity, NaN, null, true, false.
09:54:54         This can be used to raise an exception if invalid JSON numbers
09:54:54         are encountered.
09:54:54     
09:54:54         To use a custom ``JSONDecoder`` subclass, specify it with the ``cls``
09:54:54         kwarg; otherwise ``JSONDecoder`` is used.
09:54:54     
09:54:54         The ``encoding`` argument is ignored and deprecated.
09:54:54     
09:54:54         """
09:54:54         if not isinstance(s, str):
09:54:54             raise TypeError('the JSON object must be str, not {!r}'.format(
09:54:54 >                               s.__class__.__name__))
09:54:54 E           TypeError: the JSON object must be str, not 'bytes'
09:54:54 
09:54:54 /usr/lib64/python3.4/json/__init__.py:312: TypeError
09:54:54 ===================== 1 failed, 6 passed in 13.19 seconds ======================
```